### PR TITLE
Add Minimal REPL

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -42,7 +42,7 @@ impl<'a> Lexer<'a> {
             input: input,
             position: 0,
             read_position: 0,
-            ch: Some(' '),
+            ch: None,
             keyword_map: KeywordMap::new(),
         };
         l.read_char();
@@ -62,7 +62,7 @@ impl<'a> Lexer<'a> {
     pub fn next_token(&mut self) -> token::Token {
         self.skip_whitespace();
         let tok: token::Token = match self.ch {
-            None => token::Token::new(token::EOF, None),
+            None => return token::Token::new(token::EOF, None),
             Some(';') => token::Token::new(token::SEMICOLON, self.ch),
             Some('(') => token::Token::new(token::LPAREN, self.ch),
             Some(')') => token::Token::new(token::RPAREN, self.ch),
@@ -120,9 +120,11 @@ impl<'a> Lexer<'a> {
     }
 
     pub fn skip_whitespace(&mut self) {
-        if self.ch == None {
-            return;
+        if self.read_position >= self.input.len() as u32 {
+            self.ch = None;
+            return
         }
+
         while self.ch.unwrap() == ' '
             || self.ch.unwrap() == '\n'
             || self.ch.unwrap() == '\t'

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use std::io;
 
 mod lexer;
 mod token;
+mod repl;
 
 fn main() {
+    repl::start();
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,0 +1,21 @@
+use std::io;
+use super::lexer;
+use super::token;
+
+pub fn start() {
+    let mut input = String::new();
+    println!("Welcome to hell...");
+    match io::stdin().read_line(&mut input) {
+        Ok(n) => {
+            let mut l : super::lexer::Lexer = super::lexer::Lexer::new(&input);
+            loop {
+                let mut tok : super::token::Token = l.next_token();
+                if tok._type == super::token::EOF{
+                    break;
+                }
+                println!("Token [ type: {} | literal: {} ]", tok._type, tok.literal);
+            }
+        }
+        Err(error) => println!("error: {}", error),
+    }
+}

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -9,7 +9,7 @@ impl<'a> Token<'a> {
     pub fn new(token_type: TokenType, ch: Option<char>) -> Token {
         let mut l = ' '.to_string();
         if ch != None {
-            l = ch.unwrap().to_string()
+            l   = ch.unwrap().to_string();
         }
         Token {
             _type: token_type,


### PR DESCRIPTION
Adds a minimal REPL for sanity checking.
Currently only tokenizes input strings and
does not have state.